### PR TITLE
Misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 cadastre-*.tar
 
-.elixir_ls
+# Temporary files, for example, from tests.
+/tmp/
 
+# Misc.
 .DS_Store

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2020 Serge Karpiesz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Cadastre
-https://hexdocs.pm/cadastre
 
-A repository of languages, countries and country subdivisions from the iso-codes Debian package.
+[![Module Version](https://img.shields.io/hexpm/v/cadastre.svg)](https://hex.pm/packages/cadastre)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/cadastre/)
+[![Total Download](https://img.shields.io/hexpm/dt/cadastre.svg)](https://hex.pm/packages/cadastre)
+[![License](https://img.shields.io/hexpm/l/cadastre.svg)](https://github.com/Recruitee/cadastre/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/Recruitee/cadastre.svg)](https://github.com/Recruitee/cadastre/commits/master)
+
+A repository of languages, countries and country subdivisions from the
+[iso-codes](https://packages.debian.org/sid/iso-codes) Debian package.
 
 ## Installation
 
-The package can be installed
-by adding `cadastre` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `:cadastre` to your list of dependencies
+in `mix.exs`:
 
 ```elixir
 def deps do
@@ -18,7 +24,13 @@ end
 
 ## Development
 
-The `lib` directory is compiled to the library, the `dev` directory is only for development (downloading data and creating *.json and *.po files).
+The `lib` directory is compiled to the library, the `dev` directory is only for development (downloading data and creating `*.json` and `*.po` files).
 
 Run `mix load_data` to download new ISO data.
 Run `mix update_data` to add it to the project.
+
+## Copyright and License
+
+Copyright (c) 2020 Serge Karpiesz
+
+This library is released under [MIT licensed](./LICENSE.md).

--- a/lib/cadastre/country.ex
+++ b/lib/cadastre/country.ex
@@ -1,6 +1,6 @@
 defmodule Cadastre.Country do
   @moduledoc """
-  Country implementation
+  Country implementation.
   """
   alias Cadastre.Language
 
@@ -16,51 +16,50 @@ defmodule Cadastre.Country do
   ids = external_data |> Enum.map(&elem(&1, 0))
 
   @doc """
-  Return all ids (ISO_3166-1)
+  Returns all ids (ISO_3166-1).
 
   ## Examples
-  ```
-  iex> Cadastre.Country.ids() |> Enum.take(10)
-  ["AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR"]
-  ```
+
+      iex> Cadastre.Country.ids() |> Enum.take(10)
+      ["AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR"]
+
   """
   @spec ids :: [id]
   def ids, do: unquote(ids)
 
   @doc """
-  Returns all countries
+  Returns all countries.
 
   ## Examples
-  ```
-  iex> Cadastre.Country.all() |> Enum.take(3)
-  [
-    %Cadastre.Country{id: "AD"},
-    %Cadastre.Country{id: "AE"},
-    %Cadastre.Country{id: "AF"}
-  ]
 
-  iex> Cadastre.Country.all() |> Enum.count()
-  249
-  ```
+      iex> Cadastre.Country.all() |> Enum.take(3)
+      [
+        %Cadastre.Country{id: "AD"},
+        %Cadastre.Country{id: "AE"},
+        %Cadastre.Country{id: "AF"}
+      ]
+
+      iex> Cadastre.Country.all() |> Enum.count()
+      249
+
   """
   @spec all :: [t]
   def all, do: ids() |> Enum.map(&%__MODULE__{id: &1})
 
   @doc """
-  Returns `%Cadastre.Country{}` for valid `id`.
-  Returns `nil` for invalid `id`.
+  Returns `%Cadastre.Country{}` for valid `id` or `nil` for invalid `id`.
 
   ## Examples
-  ```
-  iex> Cadastre.Country.new("NL")
-  %Cadastre.Country{id: "NL"}
 
-  iex> Cadastre.Country.new("nl")
-  %Cadastre.Country{id: "NL"}
+      iex> Cadastre.Country.new("NL")
+      %Cadastre.Country{id: "NL"}
 
-  iex> Cadastre.Country.new("xx")
-  nil
-  ```
+      iex> Cadastre.Country.new("nl")
+      %Cadastre.Country{id: "NL"}
+
+      iex> Cadastre.Country.new("xx")
+      nil
+
   """
   @spec new(id | any) :: t | nil
   def new(id) when id in unquote(ids), do: %__MODULE__{id: id}
@@ -80,16 +79,16 @@ defmodule Cadastre.Country do
   Returns country name translation for `locale`
 
   ## Examples
-  ```
-  iex> Cadastre.Country.new("NL") |> Cadastre.Country.name("be")
-  "Нідэрланды"
 
-  iex> Cadastre.Country.new("NL") |> Cadastre.Country.name(":)")
-  "Netherlands"
+      iex> Cadastre.Country.new("NL") |> Cadastre.Country.name("be")
+      "Нідэрланды"
 
-  iex> Cadastre.Country.name("something wrong", "be")
-  nil
-  ```
+      iex> Cadastre.Country.new("NL") |> Cadastre.Country.name(":)")
+      "Netherlands"
+
+      iex> Cadastre.Country.name("something wrong", "be")
+      nil
+
   """
   @spec name(t, Language.id()) :: String.t()
   def name(country, locale)

--- a/lib/cadastre/language.ex
+++ b/lib/cadastre/language.ex
@@ -1,6 +1,6 @@
 defmodule Cadastre.Language do
   @moduledoc """
-  Language implementation
+  Language implementation.
   """
   @external_resource Application.app_dir(:cadastre, "priv/data/languages.etf")
 
@@ -14,51 +14,50 @@ defmodule Cadastre.Language do
   ids = external_data |> Enum.map(&elem(&1, 0))
 
   @doc """
-  Return all ids (ISO_639-2)
+  Returns all ids (ISO_639-2).
 
   ## Examples
-  ```
-  iex> Cadastre.Language.ids() |> Enum.take(10)
-  ["aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av"]
-  ```
+
+      iex> Cadastre.Language.ids() |> Enum.take(10)
+      ["aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av"]
+
   """
   @spec ids :: [id]
   def ids, do: unquote(ids)
 
   @doc """
-  Returns all languages
+  Returns all languages.
 
   ## Examples
-  ```
-  iex> Cadastre.Language.all() |> Enum.take(3)
-  [
-    %Cadastre.Language{id: "aa"},
-    %Cadastre.Language{id: "ab"},
-    %Cadastre.Language{id: "ae"}
-  ]
 
-  iex> Cadastre.Language.all() |> Enum.count()
-  178
-  ```
+      iex> Cadastre.Language.all() |> Enum.take(3)
+      [
+        %Cadastre.Language{id: "aa"},
+        %Cadastre.Language{id: "ab"},
+        %Cadastre.Language{id: "ae"}
+      ]
+
+      iex> Cadastre.Language.all() |> Enum.count()
+      178
+
   """
   @spec all :: [t]
   def all, do: ids() |> Enum.map(&%__MODULE__{id: &1})
 
   @doc """
-  Returns `%Cadastre.Language{}` for valid `id`.
-  Returns `nil` for invalid `id`.
+  Returns `%Cadastre.Language{}` for valid `id` or `nil` for invalid `id`.
 
   ## Examples
-  ```
-  iex> Cadastre.Language.new("nl")
-  %Cadastre.Language{id: "nl"}
 
-  iex> Cadastre.Language.new("NL")
-  %Cadastre.Language{id: "nl"}
+      iex> Cadastre.Language.new("nl")
+      %Cadastre.Language{id: "nl"}
 
-  iex> Cadastre.Language.new("xx")
-  nil
-  ```
+      iex> Cadastre.Language.new("NL")
+      %Cadastre.Language{id: "nl"}
+
+      iex> Cadastre.Language.new("xx")
+      nil
+
   """
   @spec new(id | any) :: t | nil
   def new(id) when id in unquote(ids), do: %__MODULE__{id: id}
@@ -75,19 +74,19 @@ defmodule Cadastre.Language do
   def new(_), do: nil
 
   @doc """
-  Returns language name translation for `locale`
+  Returns language name translation for `locale`.
 
   ## Examples
-  ```
-  iex> Cadastre.Language.new("nl") |> Cadastre.Language.name("be")
-  "галандская"
 
-  iex> Cadastre.Language.new("nl") |> Cadastre.Language.name(":)")
-  "Dutch"
+      iex> Cadastre.Language.new("nl") |> Cadastre.Language.name("be")
+      "галандская"
 
-  iex> Cadastre.Language.name("something wrong", "be")
-  nil
-  ```
+      iex> Cadastre.Language.new("nl") |> Cadastre.Language.name(":)")
+      "Dutch"
+
+      iex> Cadastre.Language.name("something wrong", "be")
+      nil
+
   """
   @spec name(t, id) :: String.t()
   def name(language, locale)
@@ -105,16 +104,16 @@ defmodule Cadastre.Language do
   def name(_, _), do: nil
 
   @doc """
-  Returns language native name
+  Returns language native name.
 
   ## Examples
-  ```
-  iex> Cadastre.Language.new("nl") |> Cadastre.Language.native_name()
-  "Nederlands"
 
-  iex> Cadastre.Language.native_name("something wrong")
-  nil
-  ```
+      iex> Cadastre.Language.new("nl") |> Cadastre.Language.native_name()
+      "Nederlands"
+
+      iex> Cadastre.Language.native_name("something wrong")
+      nil
+
   """
   @spec native_name(t) :: String.t()
   def native_name(%__MODULE__{id: id} = language), do: name(language, id)

--- a/lib/cadastre/subdivision.ex
+++ b/lib/cadastre/subdivision.ex
@@ -1,7 +1,8 @@
 defmodule Cadastre.Subdivision do
   @moduledoc """
-  Subdivision implementation
+  Subdivision implementation.
   """
+
   alias Cadastre.Country
   alias Cadastre.Language
 
@@ -17,23 +18,23 @@ defmodule Cadastre.Subdivision do
   id_per_country_id = external_data |> Map.new(fn {k, v} -> {k, Enum.map(v, &elem(&1, 0))} end)
 
   @doc """
-  Returns all subdivision ids (ISO_3166-2) for country.
-  Returns empty list for invalid argument.
+  Returns all subdivision ids (ISO_3166-2) for country or empty list for
+  invalid argument.
 
   ## Examples
-  ```
-  iex> Cadastre.Subdivision.ids("SL")
-  ["E", "N", "NW", "S", "W"]
 
-  iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.ids()
-  ["E", "N", "NW", "S", "W"]
+      iex> Cadastre.Subdivision.ids("SL")
+      ["E", "N", "NW", "S", "W"]
 
-  iex> Cadastre.Subdivision.ids("XX")
-  []
+      iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.ids()
+      ["E", "N", "NW", "S", "W"]
 
-  iex> Cadastre.Subdivision.ids(nil)
-  []
-  ```
+      iex> Cadastre.Subdivision.ids("XX")
+      []
+
+      iex> Cadastre.Subdivision.ids(nil)
+      []
+
   """
   @spec ids(Country.t() | Country.id() | any) :: [id]
   def ids(country_or_country_id) do
@@ -41,35 +42,34 @@ defmodule Cadastre.Subdivision do
   end
 
   @doc """
-  Returns subdivisions for country.
-  Returns empty list for invalid argument.
+  Returns subdivisions for country or empty list for invalid argument.
 
   ## Examples
-  ```
-  iex> Cadastre.Subdivision.all("SL")
-  [
-    %Cadastre.Subdivision{country_id: "SL", id: "E"},
-    %Cadastre.Subdivision{country_id: "SL", id: "N"},
-    %Cadastre.Subdivision{country_id: "SL", id: "NW"},
-    %Cadastre.Subdivision{country_id: "SL", id: "S"},
-    %Cadastre.Subdivision{country_id: "SL", id: "W"}
-  ]
 
-  iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.all()
-  [
-    %Cadastre.Subdivision{country_id: "SL", id: "E"},
-    %Cadastre.Subdivision{country_id: "SL", id: "N"},
-    %Cadastre.Subdivision{country_id: "SL", id: "NW"},
-    %Cadastre.Subdivision{country_id: "SL", id: "S"},
-    %Cadastre.Subdivision{country_id: "SL", id: "W"}
-  ]
+      iex> Cadastre.Subdivision.all("SL")
+      [
+        %Cadastre.Subdivision{country_id: "SL", id: "E"},
+        %Cadastre.Subdivision{country_id: "SL", id: "N"},
+        %Cadastre.Subdivision{country_id: "SL", id: "NW"},
+        %Cadastre.Subdivision{country_id: "SL", id: "S"},
+        %Cadastre.Subdivision{country_id: "SL", id: "W"}
+      ]
 
-  iex> Cadastre.Subdivision.all("XX")
-  []
+      iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.all()
+      [
+        %Cadastre.Subdivision{country_id: "SL", id: "E"},
+        %Cadastre.Subdivision{country_id: "SL", id: "N"},
+        %Cadastre.Subdivision{country_id: "SL", id: "NW"},
+        %Cadastre.Subdivision{country_id: "SL", id: "S"},
+        %Cadastre.Subdivision{country_id: "SL", id: "W"}
+      ]
 
-  iex> Cadastre.Subdivision.all(nil)
-  []
-  ```
+      iex> Cadastre.Subdivision.all("XX")
+      []
+
+      iex> Cadastre.Subdivision.all(nil)
+      []
+
   """
   @spec all(Country.t() | Country.id() | any) :: [t]
   def all(country_or_country_id) do
@@ -78,29 +78,29 @@ defmodule Cadastre.Subdivision do
   end
 
   @doc """
-  Returns `%Cadastre.Subdivision{}` for valid country/country_id and id.
-  Returns `nil` for invalid country/country_id and id.
+  Returns `%Cadastre.Subdivision{}` for valid country/country_id and id or
+  `nil` for invalid country/country_id and id.
 
   ## Examples
-  ```
-  iex> Cadastre.Subdivision.new("SL", "W")
-  %Cadastre.Subdivision{country_id: "SL", id: "W"}
 
-  iex> Cadastre.Subdivision.new("sl", "w")
-  %Cadastre.Subdivision{country_id: "SL", id: "W"}
+      iex> Cadastre.Subdivision.new("SL", "W")
+      %Cadastre.Subdivision{country_id: "SL", id: "W"}
 
-  iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.new("W")
-  %Cadastre.Subdivision{country_id: "SL", id: "W"}
+      iex> Cadastre.Subdivision.new("sl", "w")
+      %Cadastre.Subdivision{country_id: "SL", id: "W"}
 
-  iex> Cadastre.Subdivision.new("NL", "W")
-  nil
+      iex> "SL" |> Cadastre.Country.new() |> Cadastre.Subdivision.new("W")
+      %Cadastre.Subdivision{country_id: "SL", id: "W"}
 
-  iex> Cadastre.Subdivision.new("SL", "X")
-  nil
+      iex> Cadastre.Subdivision.new("NL", "W")
+      nil
 
-  iex> Cadastre.Subdivision.new(nil, nil)
-  nil
-  ```
+      iex> Cadastre.Subdivision.new("SL", "X")
+      nil
+
+      iex> Cadastre.Subdivision.new(nil, nil)
+      nil
+
   """
   @spec new(Country.t() | Country.id() | any, id | any) :: t | nil
   def new(country_or_country_id, id) when is_binary(id) do
@@ -123,19 +123,19 @@ defmodule Cadastre.Subdivision do
   def new(_, _), do: nil
 
   @doc """
-  Returns subdivision name translation for `locale`
+  Returns subdivision name translation for `locale`.
 
   ## Examples
-  ```
-  iex> Cadastre.Subdivision.new("SL", "W") |> Cadastre.Subdivision.name("be")
-  "Заходняя вобласць"
 
-  iex> Cadastre.Subdivision.new("SL", "W") |> Cadastre.Subdivision.name(":)")
-  "Western Area (Freetown)"
+      iex> Cadastre.Subdivision.new("SL", "W") |> Cadastre.Subdivision.name("be")
+      "Заходняя вобласць"
 
-  iex> Cadastre.Subdivision.name("something wrong", "be")
-  nil
-  ```
+      iex> Cadastre.Subdivision.new("SL", "W") |> Cadastre.Subdivision.name(":)")
+      "Western Area (Freetown)"
+
+      iex> Cadastre.Subdivision.name("something wrong", "be")
+      nil
+
   """
   @spec name(t, Language.id()) :: String.t()
   def name(subdivision, locale)

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,8 @@
 defmodule Cadastre.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
-  @description "A repository of languages, countries and country subdivisions from the iso-codes Debian package."
   @source_url "https://github.com/Recruitee/cadastre"
+  @version "0.2.4"
 
   def project do
     [
@@ -11,8 +10,6 @@ defmodule Cadastre.MixProject do
       app: :cadastre,
       version: @version,
       elixir: "~> 1.8",
-      description: @description,
-      source_url: @source_url,
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -45,23 +42,32 @@ defmodule Cadastre.MixProject do
       # Dev tools
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:credo, "~> 1.1", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 
   def docs do
     [
+      extras: [
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
       main: "readme",
-      extras: ["README.md"]
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 
   defp package do
     [
-      # These are the default files included in the package
+      description:
+        "A repository of languages, countries and country " <>
+          " subdivisions from the iso-codes Debian package.",
+      maintainers: ["Serge Karpiesz"],
       files: ["lib", "priv/data/*.etf", ".formatter.exs", "mix.exs", "README.md"],
-      links: %{"GitHub" => @source_url},
-      licenses: ["MIT"]
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.